### PR TITLE
Use dependencies from git when building locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,8 +257,7 @@ checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 [[package]]
 name = "lightning"
 version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f99cce0a9a62b73144dad86cf9d722379db3de049fec5df8f5437a6c92542ab"
+source = "git+https://github.com/rust-bitcoin/rust-lightning#7297e138716ec34147e591e125a96aa8a2cb2903"
 dependencies = [
  "bitcoin",
 ]
@@ -266,8 +265,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd5d18b3f9c4f7ab6c5554411f2e6618f98e4b7dcb6426be2266267dfa8d499"
+source = "git+https://github.com/rust-bitcoin/rust-lightning#7297e138716ec34147e591e125a96aa8a2cb2903"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -277,8 +275,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a773c6711f798c04e14bff4a83220c7d47d9f76cecf6cc5754693b2600f7d1"
+source = "git+https://github.com/rust-bitcoin/rust-lightning#7297e138716ec34147e591e125a96aa8a2cb2903"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -291,8 +288,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0738f41c16a3501726c4ada573cad59835e4ee66c1e7d08a4ae4d6b7baa9268"
+source = "git+https://github.com/rust-bitcoin/rust-lightning#7297e138716ec34147e591e125a96aa8a2cb2903"
 dependencies = [
  "bech32 0.7.2",
  "bitcoin_hashes",
@@ -304,8 +300,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c593aacfff258a317513a409088b92bc1dc8fb28a4a8f2826b827553435e8d9b"
+source = "git+https://github.com/rust-bitcoin/rust-lightning#7297e138716ec34147e591e125a96aa8a2cb2903"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -315,8 +310,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83dc14f2dfed0a6eaddae9e2b54998e327f63fc0bcb64bdb3133a7f20c1536e0"
+source = "git+https://github.com/rust-bitcoin/rust-lightning#7297e138716ec34147e591e125a96aa8a2cb2903"
 dependencies = [
  "bitcoin",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightning = "0.0.14"
-lightning-block-sync = { version = "0.0.14", features = [ "rpc-client" ] }
-lightning-invoice = "0.5"
-lightning-net-tokio = "0.0.14"
-lightning-persister = "0.0.14"
-lightning-background-processor = "0.0.14"
+lightning = { version = "0.0.14", git = "https://github.com/rust-bitcoin/rust-lightning" }
+lightning-block-sync = { version = "0.0.14", git = "https://github.com/rust-bitcoin/rust-lightning", features = [ "rpc-client" ] }
+lightning-invoice = { version = "0.5", git = "https://github.com/rust-bitcoin/rust-lightning" }
+lightning-net-tokio = { version = "0.0.14", git = "https://github.com/rust-bitcoin/rust-lightning" }
+lightning-persister = { version = "0.0.14", git = "https://github.com/rust-bitcoin/rust-lightning" }
+lightning-background-processor = { version = "0.0.14", git = "https://github.com/rust-bitcoin/rust-lightning" }
 
 base64 = "0.13.0"
 bitcoin = "0.26"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -406,7 +406,7 @@ fn list_channels(channel_manager: Arc<ChannelManager>) {
 		}
 		println!("\t\tpending_open: {},", pending_channel);
 		println!("\t\tchannel_value_satoshis: {},", chan_info.channel_value_satoshis);
-		println!("\t\tchannel_can_send_payments: {},", chan_info.is_live);
+		println!("\t\tchannel_can_send_payments: {},", chan_info.is_usable);
 		println!("\t}},");
 	}
 	println!("]");


### PR DESCRIPTION
Specifying a version number for dependencies prevents building against
recent changes upstream. However, either `path` or `git` can be given to
be used locally while `version` is still used when publishing to a
registry like crates.io. For details, see:

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations