### PR TITLE
Explicitly stop BackgroundProcessor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -536,7 +536,7 @@ async fn start_ldk() {
 	let persist_channel_manager_callback =
 		move |node: &ChannelManager| FilesystemPersister::persist_manager(data_dir.clone(), &*node);
 	// Step 17: Background Processing
-	BackgroundProcessor::start(
+	let background_processor = BackgroundProcessor::start(
 		persist_channel_manager_callback,
 		event_handler,
 		chain_monitor.clone(),
@@ -595,6 +595,9 @@ async fn start_ldk() {
 		network,
 	)
 	.await;
+
+	// Stop the background processor.
+	background_processor.stop().unwrap();
 }
 
 #[tokio::main]


### PR DESCRIPTION
An upcoming change will stop the `BackgroundProcessor`'s thread upon drop. Store the processor in a variable and explicitly stop it. Otherwise, the thread would be stopped immediately after it is started.