### PR TITLE
Allow "rejecting replacement" tx broadcast error

### DIFF
--- a/src/bitcoind_client.rs
+++ b/src/bitcoind_client.rs
@@ -262,6 +262,7 @@ impl BroadcasterInterface for BitcoindClient {
 						&& !err_str.contains("Inputs missing or spent")
 						&& !err_str.contains("bad-txns-inputs-missingorspent")
 						&& !err_str.contains("non-BIP68-final")
+						&& !err_str.contains("insufficient fee, rejecting replacement ")
 					{
 						panic!("{}", e);
 					}


### PR DESCRIPTION
We occasionally will attempt to broadcast transactions which conflicting
with mempool transactions which are marked RBF. If we don't have a
higher fee, we'll get a "rejecting replacement" error, which should not
cause a panic.