### PR TITLE
Drop unused change output calculation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,8 +129,6 @@ async fn handle_ldk_events(
 			// Have your wallet put the inputs into the transaction such that the output is
 			// satisfied.
 			let funded_tx = bitcoind_client.fund_raw_transaction(raw_tx).await;
-			let change_output_position = funded_tx.changepos;
-			assert!(change_output_position == 0 || change_output_position == 1);
 
 			// Sign the final funding transaction and broadcast it.
 			let signed_tx = bitcoind_client.sign_raw_transaction_with_wallet(funded_tx.hex).await;


### PR DESCRIPTION
We don't need this at all anymore since LDK automatically scans
for the correct output index these days.

Fixes #31.