### PR TITLE
Update sample for 0.0.103

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,12 +47,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
 
 [[package]]
-name = "bumpalo"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
-
-[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,22 +65,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
-
-[[package]]
-name = "const_fn"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -216,12 +205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "ldk-tutorial-node"
 version = "0.1.0"
 dependencies = [
@@ -229,6 +212,7 @@ dependencies = [
  "bech32",
  "bitcoin",
  "bitcoin-bech32",
+ "chrono",
  "futures",
  "hex",
  "lightning",
@@ -239,7 +223,6 @@ dependencies = [
  "lightning-persister",
  "rand",
  "serde_json",
- "time",
  "tokio",
 ]
 
@@ -251,8 +234,9 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "lightning"
-version = "0.0.100"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=d523b6e#d523b6e42b5b0fde07a89770906e0193ea987538"
+version = "0.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4cc6a6bc500226fe2716b8557fe66b57fd8d86348e4478b57de13a4dd6b8f0"
 dependencies = [
  "bitcoin",
  "secp256k1",
@@ -260,8 +244,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-background-processor"
-version = "0.0.100"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=d523b6e#d523b6e42b5b0fde07a89770906e0193ea987538"
+version = "0.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0cded269444c0b1d19d92b79a60b1d9188f377c2e7ddd6d0c8860b80f3ea4a"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -270,12 +255,12 @@ dependencies = [
 
 [[package]]
 name = "lightning-block-sync"
-version = "0.0.100"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=d523b6e#d523b6e42b5b0fde07a89770906e0193ea987538"
+version = "0.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0af7169b0f238dd5c845ee1d95201fbb69acb2b93d9aea5a75b6d593abcd674f"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
- "futures",
  "lightning",
  "serde",
  "serde_json",
@@ -283,8 +268,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.8.0"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=d523b6e#d523b6e42b5b0fde07a89770906e0193ea987538"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f7cc25650f634e074b0b64a793ac535f7ad2ae418dd7f0ac88972832d2f22bc"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -295,8 +281,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-net-tokio"
-version = "0.0.100"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=d523b6e#d523b6e42b5b0fde07a89770906e0193ea987538"
+version = "0.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4ba9c57851bfaa872a9fbea41065812d03da30bf24680e08c074b972cb3e8d"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -305,8 +292,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-persister"
-version = "0.0.100"
-source = "git+https://github.com/rust-bitcoin/rust-lightning?rev=d523b6e#d523b6e42b5b0fde07a89770906e0193ea987538"
+version = "0.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea68c7b0a8b0bc01103d189206bd09c8501bd0fad721229d1e36743a80ed010"
 dependencies = [
  "bitcoin",
  "libc",
@@ -358,6 +346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -459,15 +457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,21 +479,6 @@ checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -538,74 +512,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
-
-[[package]]
 name = "slab"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
-
-[[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "syn"
@@ -620,40 +530,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
- "const_fn",
  "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
+ "wasi",
  "winapi",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
 ]
 
 [[package]]
@@ -691,64 +574,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "version_check"
-version = "0.9.3"
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightning = { version = "0.0.102" }
-lightning-block-sync = { version = "0.0.102", features = [ "rpc-client" ] }
-lightning-invoice = { version = "0.10.0" }
-lightning-net-tokio = { version = "0.0.102" }
-lightning-persister = { version = "0.0.102" }
-lightning-background-processor = { version = "0.0.102" }
+lightning = { version = "0.0.103" }
+lightning-block-sync = { version = "0.0.103", features = [ "rpc-client" ] }
+lightning-invoice = { version = "0.11.0" }
+lightning-net-tokio = { version = "0.0.103" }
+lightning-persister = { version = "0.0.103" }
+lightning-background-processor = { version = "0.0.103" }
 
 base64 = "0.13.0"
 bitcoin = "0.27"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,21 +1,22 @@
 use crate::disk;
 use crate::hex_utils;
 use crate::{
-	ChannelManager, FilesystemLogger, HTLCStatus, MillisatAmount, PaymentInfo, PaymentInfoStorage,
-	PeerManager,
+	ChannelManager, FilesystemLogger, HTLCStatus, InvoicePayer, MillisatAmount, PaymentInfo,
+	PaymentInfoStorage, PeerManager,
 };
 use bitcoin::hashes::Hash;
 use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::key::PublicKey;
 use lightning::chain::keysinterface::{KeysInterface, KeysManager};
-use lightning::ln::features::InvoiceFeatures;
 use lightning::ln::msgs::NetAddress;
-use lightning::ln::{PaymentHash, PaymentSecret};
+use lightning::ln::PaymentHash;
 use lightning::routing::network_graph::NetworkGraph;
 use lightning::routing::router;
-use lightning::routing::router::{Payee, RouteHint, RouteParameters};
+use lightning::routing::router::{Payee, RouteParameters};
 use lightning::routing::scorer::Scorer;
 use lightning::util::config::{ChannelConfig, ChannelHandshakeLimits, UserConfig};
+use lightning::util::events::EventHandler;
+use lightning_invoice::payment::PaymentError;
 use lightning_invoice::{utils, Currency, Invoice};
 use std::env;
 use std::io;
@@ -24,7 +25,7 @@ use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::ops::Deref;
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub(crate) struct LdkUserInfo {
@@ -139,9 +140,10 @@ pub(crate) fn parse_startup_args() -> Result<LdkUserInfo, ()> {
 	})
 }
 
-pub(crate) async fn poll_for_user_input(
-	peer_manager: Arc<PeerManager>, channel_manager: Arc<ChannelManager>,
-	keys_manager: Arc<KeysManager>, network_graph: Arc<NetworkGraph>,
+pub(crate) async fn poll_for_user_input<E: EventHandler>(
+	invoice_payer: Arc<InvoicePayer<E>>, peer_manager: Arc<PeerManager>,
+	channel_manager: Arc<ChannelManager>, keys_manager: Arc<KeysManager>,
+	network_graph: Arc<NetworkGraph>, scorer: Arc<Mutex<Scorer>>,
 	inbound_payments: PaymentInfoStorage, outbound_payments: PaymentInfoStorage,
 	ldk_data_dir: String, logger: Arc<FilesystemLogger>, network: Network,
 ) {
@@ -240,35 +242,8 @@ pub(crate) async fn poll_for_user_input(
 							continue;
 						}
 					};
-					let last_hops = invoice.route_hints();
 
-					let amt_msat = invoice.amount_milli_satoshis();
-					if amt_msat.is_none() {
-						println!("ERROR: invalid invoice: must contain amount to pay");
-						print!("> ");
-						io::stdout().flush().unwrap();
-						continue;
-					}
-
-					let payee_pubkey = invoice.recover_payee_pub_key();
-					let final_cltv = invoice.min_final_cltv_expiry() as u32;
-					let payment_hash = PaymentHash(invoice.payment_hash().clone().into_inner());
-					let payment_secret = Some(invoice.payment_secret().clone());
-					let invoice_features = invoice.features().cloned();
-
-					send_payment(
-						payee_pubkey,
-						amt_msat.unwrap(),
-						final_cltv,
-						payment_hash,
-						payment_secret,
-						invoice_features,
-						last_hops,
-						network_graph.clone(),
-						channel_manager.clone(),
-						outbound_payments.clone(),
-						logger.clone(),
-					);
+					send_payment(&*invoice_payer, &invoice, outbound_payments.clone());
 				}
 				"keysend" => {
 					let dest_pubkey = match words.next() {
@@ -314,6 +289,7 @@ pub(crate) async fn poll_for_user_input(
 						channel_manager.clone(),
 						outbound_payments.clone(),
 						logger.clone(),
+						scorer.clone(),
 					);
 				}
 				"getinvoice" => {
@@ -603,46 +579,36 @@ fn open_channel(
 	}
 }
 
-fn send_payment(
-	payee_pubkey: PublicKey, amt_msat: u64, final_cltv: u32, payment_hash: PaymentHash,
-	payment_secret: Option<PaymentSecret>, payee_features: Option<InvoiceFeatures>,
-	route_hints: Vec<RouteHint>, network_graph: Arc<NetworkGraph>,
-	channel_manager: Arc<ChannelManager>, payment_storage: PaymentInfoStorage,
-	logger: Arc<FilesystemLogger>,
+fn send_payment<E: EventHandler>(
+	invoice_payer: &InvoicePayer<E>, invoice: &Invoice, payment_storage: PaymentInfoStorage,
 ) {
-	let first_hops = channel_manager.list_usable_channels();
-	let payer_pubkey = channel_manager.get_our_node_id();
-
-	let mut payee = Payee::from_node_id(payee_pubkey).with_route_hints(route_hints);
-	if let Some(features) = payee_features {
-		payee = payee.with_features(features);
-	}
-	let params =
-		RouteParameters { payee, final_value_msat: amt_msat, final_cltv_expiry_delta: final_cltv };
-
-	let route = router::find_route(
-		&payer_pubkey,
-		&params,
-		&network_graph,
-		Some(&first_hops.iter().collect::<Vec<_>>()),
-		logger,
-		&Scorer::default(),
-	);
-	if let Err(e) = route {
-		println!("ERROR: failed to find route: {}", e.err);
-		return;
-	}
-	let status = match channel_manager.send_payment(&route.unwrap(), payment_hash, &payment_secret)
-	{
+	let status = match invoice_payer.pay_invoice(invoice) {
 		Ok(_payment_id) => {
+			let payee_pubkey = invoice.recover_payee_pub_key();
+			let amt_msat = invoice.amount_milli_satoshis().unwrap();
 			println!("EVENT: initiated sending {} msats to {}", amt_msat, payee_pubkey);
+			print!("> ");
 			HTLCStatus::Pending
 		}
-		Err(e) => {
+		Err(PaymentError::Invoice(e)) => {
+			println!("ERROR: invalid invoice: {}", e);
+			print!("> ");
+			return;
+		}
+		Err(PaymentError::Routing(e)) => {
+			println!("ERROR: failed to find route: {}", e.err);
+			print!("> ");
+			return;
+		}
+		Err(PaymentError::Sending(e)) => {
 			println!("ERROR: failed to send payment: {:?}", e);
+			print!("> ");
 			HTLCStatus::Failed
 		}
 	};
+	let payment_hash = PaymentHash(invoice.payment_hash().clone().into_inner());
+	let payment_secret = Some(invoice.payment_secret().clone());
+
 	let mut payments = payment_storage.lock().unwrap();
 	payments.insert(
 		payment_hash,
@@ -650,7 +616,7 @@ fn send_payment(
 			preimage: None,
 			secret: payment_secret,
 			status,
-			amt_msat: MillisatAmount(Some(amt_msat)),
+			amt_msat: MillisatAmount(invoice.amount_milli_satoshis()),
 		},
 	);
 }
@@ -658,7 +624,7 @@ fn send_payment(
 fn keysend(
 	payee_pubkey: PublicKey, amt_msat: u64, network_graph: Arc<NetworkGraph>,
 	channel_manager: Arc<ChannelManager>, payment_storage: PaymentInfoStorage,
-	logger: Arc<FilesystemLogger>,
+	logger: Arc<FilesystemLogger>, scorer: Arc<Mutex<Scorer>>,
 ) {
 	let first_hops = channel_manager.list_usable_channels();
 	let payer_pubkey = channel_manager.get_our_node_id();
@@ -672,7 +638,7 @@ fn keysend(
 		&network_graph,
 		Some(&first_hops.iter().collect::<Vec<_>>()),
 		logger,
-		&Scorer::default(),
+		&scorer.lock().unwrap(),
 	) {
 		Ok(r) => r,
 		Err(e) => {


### PR DESCRIPTION
Update the sample node to use APIs from the 0.0.103 release.
- Use `InvoicePayer` for routing and sending payments
- Use `find_route` for keysend payments
- Use a single `Scorer` instance and persist it periodically