### PR TITLE
Add a bounds check before accessing a user-provided PK string

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,8 +320,8 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 						continue;
 					}
 					let channel_id_vec = hex_utils::to_vec(channel_id_str.unwrap());
-					if channel_id_vec.is_none() {
-						println!("ERROR: couldn't parse channel_id as hex");
+					if channel_id_vec.is_none() || channel_id_vec.as_ref().unwrap().len() != 32 {
+						println!("ERROR: couldn't parse channel_id");
 						continue;
 					}
 					let mut channel_id = [0; 32];
@@ -335,8 +335,8 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 						continue;
 					}
 					let channel_id_vec = hex_utils::to_vec(channel_id_str.unwrap());
-					if channel_id_vec.is_none() {
-						println!("ERROR: couldn't parse channel_id as hex");
+					if channel_id_vec.is_none() || channel_id_vec.as_ref().unwrap().len() != 32 {
+						println!("ERROR: couldn't parse channel_id");
 						continue;
 					}
 					let mut channel_id = [0; 32];

--- a/src/hex_utils.rs
+++ b/src/hex_utils.rs
@@ -31,6 +31,9 @@ pub fn hex_str(value: &[u8]) -> String {
 }
 
 pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
+	if hex.len() != 33 * 2 {
+		return None;
+	}
 	let data = match to_vec(&hex[0..33 * 2]) {
 		Some(bytes) => bytes,
 		None => return None,


### PR DESCRIPTION
Fixes #53.