### PR TITLE
Add --public option to openchannel command help

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -423,7 +423,7 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 }
 
 fn help() {
-	println!("openchannel pubkey@host:port <amt_satoshis>");
+	println!("openchannel pubkey@host:port <amt_satoshis> [--public]");
 	println!("sendpayment <invoice>");
 	println!("keysend <dest_pubkey> <amt_msats>");
 	println!("getinvoice <amt_msats> <expiry_secs>");


### PR DESCRIPTION
The `openchannel` command creates private channel by default, but it has `--public` option for public channel creation.  However, this option is not mentioned in the `help` output.  Include the `--public` option in the help description as well.