### PR TITLE
Update package name to `ldk-sample`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ldk-tutorial-node"
+name = "ldk-sample"
 version = "0.1.0"
 authors = ["Valentine Wallace <vwallace@protonmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
So far the name was `ldk-tutorial-node`, we now update this to align with the repository.