### PR TITLE
Update Cargo.lock to reflect new package name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "ldk-tutorial-node"
+name = "ldk-sample"
 version = "0.1.0"
 dependencies = [
  "base64",


### PR DESCRIPTION
Got this diff locally after rebasing the other PR, so just a quick PR to check the change.