### PR TITLE
Followup: Parse .cookie, .env, or environment variables for RPC auth details

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -175,7 +175,7 @@ fn get_cookie_path(
 	};
 
 	let data_dir_path_with_net = match network {
-		Some(Network::Testnet) => data_dir_path.join("testnet"),
+		Some(Network::Testnet) => data_dir_path.join("testnet3"),
 		Some(Network::Regtest) => data_dir_path.join("regtest"),
 		Some(Network::Signet) => data_dir_path.join("signet"),
 		_ => data_dir_path,
@@ -279,7 +279,7 @@ mod rpc_auth_tests {
 				Some((TEST_DATA_DIR, true)),
 				Some(Network::Testnet),
 				None,
-				env::home_dir().unwrap().join(TEST_DATA_DIR).join("testnet").join(".cookie"),
+				env::home_dir().unwrap().join(TEST_DATA_DIR).join("testnet3").join(".cookie"),
 			),
 			(
 				Some((TEST_DATA_DIR, false)),

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,9 +55,9 @@ pub(crate) fn parse_startup_args() -> Result<LdkUserInfo, ()> {
 	};
 
 	let (bitcoind_rpc_username, bitcoind_rpc_password) = if bitcoind_rpc_info_parts.len() == 1 {
-		get_rpc_auth_from_cookie(None, Some(network), None)
+		get_rpc_auth_from_env_vars()
 			.or(get_rpc_auth_from_env_file(None))
-			.or(get_rpc_auth_from_env_vars())
+			.or(get_rpc_auth_from_cookie(None, Some(network), None))
 			.or({
 				println!("ERROR: unable to get bitcoind RPC username and password");
 				print_rpc_auth_help();


### PR DESCRIPTION
Following up on https://github.com/lightningdevkit/ldk-sample/pull/87#pullrequestreview-1236648126.

Preferred env file over cookie because that seems to make sense if the user bothers to specify it.