### PR TITLE
Return results in JSON format with serde

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,15 +4,11 @@ use crate::{
 	ChannelManager, HTLCStatus, InvoicePayer, MillisatAmount, NetworkGraph, OnionMessenger,
 	PaymentInfo, PaymentInfoStorage, PeerManager,
 };
-use bitcoin::bech32::Error;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
 use bitcoin::network::constants::Network;
 use bitcoin::secp256k1::PublicKey;
-use futures::stream::ForEach;
-use lightning::chain::chainmonitor;
 use lightning::chain::keysinterface::{KeysInterface, KeysManager, Recipient};
-use lightning::ln::channelmanager::ChannelDetails;
 use lightning::ln::msgs::{DecodeError, NetAddress};
 use lightning::ln::{PaymentHash, PaymentPreimage};
 use lightning::onion_message::{CustomOnionMessageContents, Destination, OnionMessageContents};
@@ -23,7 +19,6 @@ use lightning::util::events::EventHandler;
 use lightning::util::ser::{MaybeReadableArgs, Writeable, Writer};
 use lightning_invoice::payment::PaymentError;
 use lightning_invoice::{utils, Currency, Invoice};
-use serde_json::from_str;
 use std::env;
 use std::io;
 use std::io::Write;
@@ -31,7 +26,6 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::ops::Deref;
 use std::path::Path;
 use std::str::FromStr;
-use std::string;
 use std::sync::Arc;
 use std::time::Duration;
 use serde_json::{json};
@@ -154,6 +148,7 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 								Path::new(&peer_data_path),
 								peer_pubkey_and_ip_addr,
 							);
+							println!("Opening new channel:\n{}", serde_json::to_string_pretty(&channel).unwrap())
 						},
 						Err(message) => {
 							println!("Error: {}", message);
@@ -752,6 +747,7 @@ fn open_channel(
 			Ok(channel_json)
 		}
 		Err(e) => {
+			println!("Error: {:?}", e);
 			Err("Failed to open channel".to_string())
 		}
 	}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -148,12 +148,12 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 								peer_pubkey_and_ip_addr,
 							);
 							println!(
-								"Opening new channel:\n{}",
+								"Channel details:\n{}",
 								serde_json::to_string_pretty(&channel).unwrap()
 							)
 						}
 						Err(message) => {
-							println!("Error: {}", message);
+							println!("ERROR: {}", message);
 						}
 					}
 				}
@@ -350,7 +350,7 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 					};
 
 					match close_channel(channel_id, peer_pubkey, channel_manager.clone()) {
-						Ok(event) => println!("EVENT: {}", event),
+						Ok(msg) => println!("SUCCESS: {}", msg),
 						Err(e) => println!("ERROR: Could not close channel\n{:?}", e),
 					}
 				}
@@ -389,20 +389,20 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 					};
 
 					match force_close_channel(channel_id, peer_pubkey, channel_manager.clone()) {
-						Ok(event) => println!("EVENT: {}", event),
+						Ok(msg) => println!("SUCCESS: {}", msg),
 						Err(e) => println!("ERROR: Could not force close channel\n{:?}", e),
 					}
 				}
 				"nodeinfo" => {
 					match node_info(&channel_manager, &peer_manager) {
 						Ok(info) => println!("{}", serde_json::to_string_pretty(&info).unwrap()),
-						Err(_) => print!("Error: Could not fetch node info"),
+						Err(_) => print!("ERROR: Could not fetch node info"),
 					};
 				}
 				"listpeers" => {
 					match list_peers(peer_manager.clone()) {
 						Ok(peers) => println!("{}", serde_json::to_string_pretty(&peers).unwrap()),
-						Err(_) => print!("Error: Could not fetch peer info"),
+						Err(_) => print!("ERROR: Could not fetch peer info"),
 					};
 				}
 				"signmessage" => {
@@ -745,7 +745,8 @@ fn open_channel(
 			println!("EVENT: initiated channel with peer {}. ", peer_pubkey);
 			let channel_json = json!({
 				"peer_pubkey": peer_pubkey.to_string(),
-				"amount": channel_amt_sat
+				"amount": channel_amt_sat,
+				"public": announced_channel
 			});
 			Ok(channel_json)
 		}
@@ -905,7 +906,7 @@ fn close_channel(
 	channel_id: [u8; 32], counterparty_node_id: PublicKey, channel_manager: Arc<ChannelManager>,
 ) -> Result<String, APIError> {
 	let result = match channel_manager.close_channel(&channel_id, &counterparty_node_id) {
-		Ok(()) => Ok("EVENT: initiating channel close".to_string()),
+		Ok(()) => Ok("Initiating channel close".to_string()),
 		Err(e) => Err(e),
 	};
 	result
@@ -917,7 +918,7 @@ fn force_close_channel(
 	let result = match channel_manager
 		.force_close_broadcasting_latest_txn(&channel_id, &counterparty_node_id)
 	{
-		Ok(()) => Ok("EVENT: initiating channel force-close".to_string()),
+		Ok(()) => Ok("Initiating channel force-close".to_string()),
 		Err(e) => Err(e),
 	};
 	result

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -304,7 +304,7 @@ pub(crate) async fn poll_for_user_input<E: EventHandler>(
 						Ok(channels) => {
 							println!("{}", serde_json::to_string_pretty(&channels).unwrap())
 						}
-						Err(_) => print!("ERROR: Could not fetch peer info"),
+						Err(_) => print!("ERROR: Could not fetch channel info"),
 					};
 				}
 				"listpayments" => {
@@ -707,7 +707,7 @@ fn do_disconnect_peer(
 	//check for open channels with peer
 	for channel in channel_manager.list_channels() {
 		if channel.counterparty.node_id == pubkey {
-			println!("Error: Node has an active channel with this peer, close any channels first");
+			println!("ERROR: Node has an active channel with this peer, close any channels first");
 			return Err(());
 		}
 	}
@@ -715,7 +715,7 @@ fn do_disconnect_peer(
 	//check the pubkey matches a valid connected peer
 	let peers = peer_manager.get_peer_node_ids();
 	if !peers.contains(&pubkey) {
-		println!("Error: Could not find peer {}", pubkey);
+		println!("ERROR: Could not find peer {}", pubkey);
 		return Err(());
 	}
 
@@ -742,7 +742,7 @@ fn open_channel(
 
 	match channel_manager.create_channel(peer_pubkey, channel_amt_sat, 0, 0, Some(config)) {
 		Ok(_) => {
-			println!("EVENT: initiated channel with peer {}. ", peer_pubkey);
+			println!("EVENT: Initiated channel with peer {}. ", peer_pubkey);
 			let channel_json = json!({
 				"peer_pubkey": peer_pubkey.to_string(),
 				"amount": channel_amt_sat,
@@ -751,7 +751,7 @@ fn open_channel(
 			Ok(channel_json)
 		}
 		Err(e) => {
-			println!("Error: {:?}", e);
+			println!("ERROR: {:?}", e);
 			Err("Failed to open channel".to_string())
 		}
 	}


### PR DESCRIPTION
The purpose of this PR is twofold: 
- To return results in JSON format instead of printing in mock-json style to console
- Return with a result type for all functions instead of just printing the error to console

Currently a lot of the responses can only be viewed in the terminal and not all functions fail on an error, instead just printing out the error and returning. It would also be difficult to use the sample node non-interactively, for example via http responses. Serde_json offers consistent formatting for responses and is already a dependency in the sample node.

The PR has the following advantages:
- Responses are in a format that can be parsed more easily. For example if implementing an API, definitive responses on channel info, connected peers etc. can be sent remotely
- Better error handling since most errors are now returned as a result rather than just been printed to console
- Improved readability, printing JSON brackets no longer necessary
- Easier to embed objects in responses, for example sent and received payments are now separate return fields