### PR TITLE
Generate on-chain addresses

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -838,7 +838,7 @@ pub(crate) fn parse_peer_info(
 async fn get_new_address(bitcoind_client: Arc<BitcoindClient>) {
 	let address = bitcoind_client.get_new_address().await;
 	println!(
-		"{{\n\t\type: {}, \n\tnetwork: {}, \n\taddress: {}\n}}",
+		"{{\n\ttype: {}, \n\tnetwork: {}, \n\taddress: {}\n}}",
 		address.address_type().unwrap(),
 		address.network,
 		address

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -838,7 +838,7 @@ pub(crate) fn parse_peer_info(
 async fn get_new_address(bitcoind_client: Arc<BitcoindClient>) {
 	let address = bitcoind_client.get_new_address().await;
 	println!(
-		"{{\n\t\"type: \"{}\", \n\t\"network: \"{}\", \n\t\"address: \"{}\"\n}}",
+		"{{\n\t\type: {}, \n\tnetwork: {}, \n\taddress: {}\n}}",
 		address.address_type().unwrap(),
 		address.network,
 		address

--- a/src/main.rs
+++ b/src/main.rs
@@ -768,6 +768,7 @@ async fn start_ldk() {
 		Arc::clone(&keys_manager),
 		Arc::clone(&network_graph),
 		Arc::clone(&onion_messenger),
+		Arc::clone(&bitcoind_client),
 		inbound_payments,
 		outbound_payments,
 		ldk_data_dir.clone(),


### PR DESCRIPTION
Uses the bitcoind client to generate on-chain address with the getnewaddress command.