### PR TITLE
Switch missed tick behavior to delay instead of default burst

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -759,6 +759,7 @@ async fn start_ldk() {
 	let stop_connect = Arc::clone(&stop_listen_connect);
 	tokio::spawn(async move {
 		let mut interval = tokio::time::interval(Duration::from_secs(1));
+		interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 		loop {
 			interval.tick().await;
 			match disk::read_channel_peer_data(Path::new(&peer_data_path)) {


### PR DESCRIPTION
We encountered an interesting bug that we fixed and felt we should upstream, as it presents itself in the sample as well.

We observed that seemingly randomly, this loop (or rather, our similar but modified one) would get "hot" and run as fast as possible. This would consume a lot of CPU and other resources, and of course meant a lot of SYN packets being sent somewhere proximal to the peer. These "reconnect storms" could last as little as a few seconds, or up to hours, after which they would spontaneously resolve.

We could observe this because we'd added logging to the reconnect attempts, so all we knew was that some loop was hot, but not which of them. We initially tried [rewriting the loop to use combinators with `take` and maximum attempt values](https://gist.github.com/domZippilli/c231ad538ed88863d781252dcc11646a), but this did not fix the problem. This suggested that the outer loop was the issue, but it took us some time to figure out how that could be.

The interval here uses the default missed tick behavior, which is `Burst`:

https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html

We believe that with a large number of peers offline (we sometimes had >5), this loop could run for longer than the `Interval` duration of one second. When this happened, the `Interval` would enter `Burst` mode and try to re-establish an exact cadence of running this loop on a whole multiple of the interval from the start.

```text
Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
Actual ticks:   | work -----|          delay          | work | work | work -| work -----|
```

We switched the interval to instead use the `Delay` behavior, which should cause this loop to wait the interval's duration (1 second) each time `tick()` is called, which is probably what the author (@TheBlueMatt) intended.

```text
Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
Actual ticks:   | work -----|          delay          | work -----| work -----| work -----|
```