### PR TITLE
Don't use `chrono` default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bech32 = "0.8"
 hex = "0.3"
 libc = "0.2"
 
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rand = "0.4"
 serde_json = { version = "1.0" }
 tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }


### PR DESCRIPTION
The `chrono` crate has a dependency on an old version of `time` which has a potential segfault. We therefore disable the default features.

See also https://github.com/lightningdevkit/ldk-node/pull/146.