### PR TITLE
Fix build errors and warnings on Windows operating system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ hex = "0.3"
 libc = "0.2"
 
 chrono = "0.4"
+home = "0.5.5"
 rand = "0.4"
 serde_json = { version = "1.0" }
-tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
+tokio = { version = "1.28.0", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,9 @@ hex = "0.3"
 libc = "0.2"
 
 chrono = "0.4"
-home = "0.5.5"
 rand = "0.4"
 serde_json = { version = "1.0" }
-tokio = { version = "1.28.0", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
+tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 
 [profile.release]
 panic = "abort"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,6 @@
 use crate::cli::LdkUserInfo;
 use bitcoin::network::constants::Network;
+use home;
 use lightning::ln::msgs::NetAddress;
 use std::collections::HashMap;
 use std::env;
@@ -130,7 +131,7 @@ const BITCOIND_RPC_PASSWORD_KEY: &str = "RPC_PASSWORD";
 
 fn print_rpc_auth_help() {
 	// Get the default data directory
-	let home_dir = env::home_dir()
+	let home_dir = home::home_dir()
 		.as_ref()
 		.map(|ref p| p.to_str())
 		.flatten()
@@ -169,9 +170,9 @@ fn get_cookie_path(
 	data_dir: Option<(&str, bool)>, network: Option<Network>, cookie_file_name: Option<&str>,
 ) -> Result<PathBuf, ()> {
 	let data_dir_path = match data_dir {
-		Some((dir, true)) => env::home_dir().ok_or(())?.join(dir),
+		Some((dir, true)) => home::home_dir().ok_or(())?.join(dir),
 		Some((dir, false)) => PathBuf::from(dir),
-		None => env::home_dir().ok_or(())?.join(DEFAULT_BITCOIN_DATADIR),
+		None => home::home_dir().ok_or(())?.join(DEFAULT_BITCOIN_DATADIR),
 	};
 
 	let data_dir_path_with_net = match network {
@@ -273,13 +274,13 @@ mod rpc_auth_tests {
 				None,
 				None,
 				None,
-				env::home_dir().unwrap().join(DEFAULT_BITCOIN_DATADIR).join(".cookie"),
+				home::home_dir().unwrap().join(DEFAULT_BITCOIN_DATADIR).join(".cookie"),
 			),
 			(
 				Some((TEST_DATA_DIR, true)),
 				Some(Network::Testnet),
 				None,
-				env::home_dir().unwrap().join(TEST_DATA_DIR).join("testnet3").join(".cookie"),
+				home::home_dir().unwrap().join(TEST_DATA_DIR).join("testnet3").join(".cookie"),
 			),
 			(
 				Some((TEST_DATA_DIR, false)),

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,6 +1,5 @@
 use crate::cli::LdkUserInfo;
 use bitcoin::network::constants::Network;
-use home;
 use lightning::ln::msgs::NetAddress;
 use std::collections::HashMap;
 use std::env;
@@ -131,7 +130,7 @@ const BITCOIND_RPC_PASSWORD_KEY: &str = "RPC_PASSWORD";
 
 fn print_rpc_auth_help() {
 	// Get the default data directory
-	let home_dir = home::home_dir()
+	let home_dir = env::home_dir()
 		.as_ref()
 		.map(|ref p| p.to_str())
 		.flatten()
@@ -170,9 +169,9 @@ fn get_cookie_path(
 	data_dir: Option<(&str, bool)>, network: Option<Network>, cookie_file_name: Option<&str>,
 ) -> Result<PathBuf, ()> {
 	let data_dir_path = match data_dir {
-		Some((dir, true)) => home::home_dir().ok_or(())?.join(dir),
+		Some((dir, true)) => env::home_dir().ok_or(())?.join(dir),
 		Some((dir, false)) => PathBuf::from(dir),
-		None => home::home_dir().ok_or(())?.join(DEFAULT_BITCOIN_DATADIR),
+		None => env::home_dir().ok_or(())?.join(DEFAULT_BITCOIN_DATADIR),
 	};
 
 	let data_dir_path_with_net = match network {
@@ -274,13 +273,13 @@ mod rpc_auth_tests {
 				None,
 				None,
 				None,
-				home::home_dir().unwrap().join(DEFAULT_BITCOIN_DATADIR).join(".cookie"),
+				env::home_dir().unwrap().join(DEFAULT_BITCOIN_DATADIR).join(".cookie"),
 			),
 			(
 				Some((TEST_DATA_DIR, true)),
 				Some(Network::Testnet),
 				None,
-				home::home_dir().unwrap().join(TEST_DATA_DIR).join("testnet3").join(".cookie"),
+				env::home_dir().unwrap().join(TEST_DATA_DIR).join("testnet3").join(".cookie"),
 			),
 			(
 				Some((TEST_DATA_DIR, false)),


### PR DESCRIPTION
1. Bumping the dependency version of tokio fixes a compile error in ntexapi.rs (see https://stackoverflow.com/questions/76173195/my-rust-project-is-broken-all-of-the-sudden)
2. Switching from std::env::home_dir() to home::home_dir() clears warnings about deprecation and unexpected behavior pertaining to Windows only.