### PR TITLE
Attempt a last-ditch ChannelManager persistence if the BP exits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -914,12 +914,11 @@ async fn start_ldk() {
 
 	// Exit if either CLI polling exits or the background processor exits (which shouldn't happen
 	// unless we fail to write to the filesystem).
+	let mut bg_res = Ok(Ok(()));
 	tokio::select! {
 		_ = cli_poll => {},
-		bg_res = &mut background_processor => {
-			stop_listen_connect.store(true, Ordering::Release);
-			peer_manager.disconnect_all_peers();
-			panic!("ERR: background processing stopped with result {:?}, exiting", bg_res);
+		bg_exit = &mut background_processor => {
+			bg_res = bg_exit;
 		},
 	}
 
@@ -927,6 +926,21 @@ async fn start_ldk() {
 	// updating our channel data after we've stopped the background processor.
 	stop_listen_connect.store(true, Ordering::Release);
 	peer_manager.disconnect_all_peers();
+
+	if let Err(e) = bg_res {
+		let persist_res = persister.persist("manager", &*channel_manager).unwrap();
+		use lightning::util::logger::Logger;
+		lightning::log_error!(
+			&*logger,
+			"Last-ditch ChannelManager persistence result: {:?}",
+			persist_res
+		);
+		panic!(
+			"ERR: background processing stopped with result {:?}, exiting.\n\
+			Last-ditch ChannelManager persistence result {:?}",
+			e, persist_res
+		);
+	}
 
 	// Stop the background processor.
 	if !bp_exit.is_closed() {


### PR DESCRIPTION
If the BP exits because it failed to write our ChannelManager to disk, we'll probably lose some channels on startup. However, there's still some chance for us to write the `ChannelManager` in a retry, which we should do before we exit.