### PR TITLE
[doc only] Fix comment on funding transaction broadcast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ async fn handle_ldk_events(
 			// satisfied.
 			let funded_tx = bitcoind_client.fund_raw_transaction(raw_tx).await;
 
-			// Sign the final funding transaction and broadcast it.
+			// Sign the final funding transaction and give it to LDK, who will eventually broadcast it.
 			let signed_tx = bitcoind_client.sign_raw_transaction_with_wallet(funded_tx.hex).await;
 			assert_eq!(signed_tx.complete, true);
 			let final_tx: Transaction =


### PR DESCRIPTION
This is a minor change of a misleading comment: the funding transaction is not broadcast by `ldk-sample`, but rather by `LDK` itself (after making sure commit transactions are available).
Some time ago this comment caused me some confusion regarding where exactly the funding transaction broadcast happens.