### PR TITLE
Avoid `offer_hash` `PaymentId` collision

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -818,7 +818,7 @@ fn send_payment(
 	let (payment_hash, recipient_onion, route_params) = match pay_params_opt {
 		Ok(res) => res,
 		Err(e) => {
-			println!("Failed to parse invoice");
+			println!("Failed to parse invoice: {:?}", e);
 			print!("> ");
 			return;
 		}


### PR DESCRIPTION
Previously, we'd deterministically derive the `offer_hash` as a `PaymentId` for outbound BOLT 12 payments. However, as offers may be paid multiple times, this could result in collisions in our
`outbound_payments` store.

Here, we therefore use random `PaymentId`s to avoid collisions, even if offers are paid multiple times.